### PR TITLE
feat(motors): counsel-001 Now sprint — PII hardening, pixel, price badges, pipe integrity, FB alert

### DIFF
--- a/app/api/motors/fb-token-check/route.ts
+++ b/app/api/motors/fb-token-check/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const GRAPH = 'https://graph.facebook.com/v25.0'
+const WARN_DAYS = 14
+
+function auth(req: NextRequest): boolean {
+  const header = req.headers.get('authorization') ?? ''
+  return header === `Bearer ${process.env.CRON_SECRET?.trim()}`
+}
+
+async function sendAlert(subject: string, body: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  const to     = process.env.MOTORS_FB_ALERT_EMAIL
+  if (!apiKey || !to) return
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method:  'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      from:    'RoadHouse Motors <hello@roadhouse.capital>',
+      to:      [to],
+      subject,
+      text:    body,
+    }),
+  })
+
+  if (!res.ok) {
+    const err = await res.text()
+    console.error(`[fb-token-check] alert email failed: Resend ${res.status}: ${err}`)
+  }
+}
+
+// GET /api/motors/fb-token-check — Bearer CRON_SECRET
+// Checks FB Page Access Token validity and expiry. Sends Resend alert if token
+// expires within WARN_DAYS days or is already invalid.
+export async function GET(req: NextRequest) {
+  if (!auth(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const token    = process.env.MOTORS_FB_PAGE_ACCESS_TOKEN
+  const appId    = process.env.MOTORS_FB_APP_ID
+  const appSecret = process.env.MOTORS_FB_APP_SECRET
+
+  if (!token) {
+    return NextResponse.json({ error: 'MOTORS_FB_PAGE_ACCESS_TOKEN not set' }, { status: 500 })
+  }
+
+  // Step 1: basic validity check via /me
+  let tokenValid = false
+  let pageId     = ''
+  try {
+    const meRes  = await fetch(`${GRAPH}/me?access_token=${encodeURIComponent(token)}&fields=id,name`)
+    const meData = await meRes.json() as { id?: string; name?: string; error?: { message: string } }
+    if (meData.error) {
+      await sendAlert(
+        'ACTION REQUIRED: RoadHouse Motors FB Token Invalid',
+        `The Facebook Page Access Token has been invalidated or expired.\n\nError: ${meData.error.message}\n\nRefresh the token at:\nhttps://business.facebook.com → Business Settings → System Users\n\nUpdate MOTORS_FB_PAGE_ACCESS_TOKEN in Vercel and FB_PAGE_ACCESS_TOKEN in GitHub Secrets.`,
+      )
+      return NextResponse.json({ status: 'invalid', error: meData.error.message })
+    }
+    tokenValid = true
+    pageId     = meData.id ?? ''
+  } catch (err) {
+    console.error('[fb-token-check] /me request failed:', err)
+    return NextResponse.json({ error: 'Failed to reach Graph API' }, { status: 500 })
+  }
+
+  // Step 2: expiry check via debug_token (requires app credentials)
+  if (tokenValid && appId && appSecret) {
+    try {
+      const debugUrl = `${GRAPH}/debug_token?input_token=${encodeURIComponent(token)}&access_token=${encodeURIComponent(`${appId}|${appSecret}`)}`
+      const debugRes  = await fetch(debugUrl)
+      const debugData = await debugRes.json() as {
+        data?: { expires_at?: number; is_valid?: boolean; error?: { message: string } }
+        error?: { message: string }
+      }
+
+      if (debugData.error || debugData.data?.error) {
+        console.warn('[fb-token-check] debug_token error:', debugData.error ?? debugData.data?.error)
+      } else if (debugData.data) {
+        const { expires_at, is_valid } = debugData.data
+
+        if (!is_valid) {
+          await sendAlert(
+            'ACTION REQUIRED: RoadHouse Motors FB Token Invalid',
+            `The Facebook Page Access Token is no longer valid (debug_token confirmed).\n\nPage ID: ${pageId}\n\nRefresh the token and update:\n• Vercel: MOTORS_FB_PAGE_ACCESS_TOKEN\n• GitHub Secrets: FB_PAGE_ACCESS_TOKEN`,
+          )
+          return NextResponse.json({ status: 'invalid' })
+        }
+
+        // expires_at == 0 means permanent token — no expiry alert needed
+        if (expires_at && expires_at > 0) {
+          const daysLeft = Math.floor((expires_at * 1000 - Date.now()) / (1000 * 60 * 60 * 24))
+          if (daysLeft <= WARN_DAYS) {
+            const expiryDate = new Date(expires_at * 1000).toISOString().split('T')[0]
+            await sendAlert(
+              `WARNING: RoadHouse Motors FB Token Expires in ${daysLeft} Day${daysLeft === 1 ? '' : 's'}`,
+              `The Facebook Page Access Token expires on ${expiryDate} (${daysLeft} day${daysLeft === 1 ? '' : 's'} remaining).\n\nPage ID: ${pageId}\n\nRefresh the token and update:\n• Vercel: MOTORS_FB_PAGE_ACCESS_TOKEN\n• GitHub Secrets: FB_PAGE_ACCESS_TOKEN\n\nToken refresh: https://business.facebook.com → Business Settings → System Users`,
+            )
+            return NextResponse.json({ status: 'expiring', daysLeft, expiresAt: expiryDate })
+          }
+          return NextResponse.json({ status: 'ok', daysLeft })
+        }
+      }
+    } catch (err) {
+      console.error('[fb-token-check] debug_token request failed:', err)
+    }
+  }
+
+  return NextResponse.json({ status: 'ok', pageId, note: appId ? undefined : 'Set MOTORS_FB_APP_ID + MOTORS_FB_APP_SECRET for full expiry check' })
+}

--- a/app/api/motors/lead/route.ts
+++ b/app/api/motors/lead/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { Redis } from '@upstash/redis'
 import type { MotorsLead } from '@/types/inventory'
 import { checkPhoneRateLimit } from '@/lib/motors/ratelimit'
+import { toE164 } from '@/lib/motors/phone'
 
 const RESEND_API = 'https://api.resend.com/emails'
 const TO_EMAIL   = 'roadhousesyndicate@gmail.com'
@@ -106,7 +107,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Phone too long' }, { status: 400 })
   }
 
-  const cleanPhone = phone.trim().replace(/\s+/g, '')
+  const cleanPhone = toE164(phone.trim())
+  if (!cleanPhone) {
+    return NextResponse.json({ error: 'Please enter a valid Canadian or US phone number' }, { status: 400 })
+  }
 
   const allowed = await checkPhoneRateLimit(cleanPhone)
   if (!allowed) {

--- a/app/api/motors/leads/route.ts
+++ b/app/api/motors/leads/route.ts
@@ -290,8 +290,8 @@ export async function GET(req: NextRequest) {
         return null
       }
     })
-    .filter(Boolean)
-    .sort((a: MotorsLead, b: MotorsLead) => b.submittedAt.localeCompare(a.submittedAt))
+    .filter((x): x is MotorsLead & Record<string, unknown> => x !== null)
+    .sort((a, b) => b.submittedAt.localeCompare(a.submittedAt))
 
   return NextResponse.json(leads)
 }

--- a/app/api/motors/leads/route.ts
+++ b/app/api/motors/leads/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Redis } from '@upstash/redis'
 import type { MotorsLead } from '@/types/inventory'
 import { checkPhoneRateLimit } from '@/lib/motors/ratelimit'
+import { encryptPII, decryptPII } from '@/lib/motors/encrypt'
+
+// 90-day TTL for pre-qualification leads (PIPEDA: retain only while purpose is active).
+// Funded deals must be migrated to the DMS before this window closes.
+const LEAD_TTL_SECONDS = 90 * 24 * 60 * 60
 
 function getRedis(): Redis {
   const url   = process.env.KV_REST_API_URL
@@ -19,7 +24,7 @@ const RESEND_API   = 'https://api.resend.com/emails'
 const MOTORS_FROM  = 'hello@roadhouse.capital'
 const MOTORS_ADMIN = 'roadhousesyndicate@gmail.com'
 
-async function sendNotification(lead: MotorsLead, raw: Record<string, string>) {
+async function sendAdminNotification(lead: MotorsLead, raw: Record<string, string>) {
   const apiKey = process.env.RESEND_API_KEY
   if (!apiKey) {
     console.warn('[motors/leads] RESEND_API_KEY not set — email suppressed')
@@ -41,6 +46,7 @@ async function sendNotification(lead: MotorsLead, raw: Record<string, string>) {
   ]
 
   if (raw.dob)           lines.push(`Date of Birth:  ${raw.dob}`)
+  if (raw.sin)           lines.push(`SIN:            ${raw.sin}`)
   if (raw.maritalStatus) lines.push(`Marital Status: ${raw.maritalStatus}`)
 
   if (raw.street) {
@@ -65,7 +71,7 @@ async function sendNotification(lead: MotorsLead, raw: Record<string, string>) {
   if (raw.monthlyPayment) lines.push(`Monthly Housing: $${Number(raw.monthlyPayment).toLocaleString('en-CA')} CAD`)
   if (raw.bankruptcy)     lines.push(`Bankruptcy:     ${raw.bankruptcy}`)
   if (raw.repossession)   lines.push(`Repossession:   ${raw.repossession}`)
-  if (raw.coSigner)       lines.push(`Co-signer:      ${raw.coSigner}`)
+  if (lead.coSigner)      lines.push(`Co-signer:      ${lead.coSigner}`)
 
   lines.push(``, `── VEHICLE INTEREST ─────────────────────────────────`)
   lines.push(`Looking for:    ${lead.vehicleInterest || '—'}`)
@@ -97,6 +103,42 @@ async function sendNotification(lead: MotorsLead, raw: Record<string, string>) {
   }
 }
 
+async function sendCustomerReceipt(lead: MotorsLead) {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey || !lead.email) return
+
+  const firstName  = lead.name.split(' ')[0]
+  const vehicleLine = lead.vehicleInterest ? `\n\nApplied for: ${lead.vehicleInterest}` : ''
+
+  const text = [
+    `Hi ${firstName},`,
+    ``,
+    `We've received your pre-qualification request and will be in touch within 1 business day.${vehicleLine}`,
+    ``,
+    `Questions? Call us at (306) 381-8222.`,
+    ``,
+    `— RoadHouse Motors`,
+    `Dealer Licence DL331386 · Saskatchewan, Canada`,
+    `https://motors.roadhouse.capital`,
+  ].join('\n')
+
+  const res = await fetch(RESEND_API, {
+    method:  'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      from:    `RoadHouse Motors <${MOTORS_FROM}>`,
+      to:      [lead.email],
+      subject: `Application received — RoadHouse Motors`,
+      text,
+    }),
+  })
+
+  if (!res.ok) {
+    const err = await res.text()
+    console.error(`[motors/leads] receipt email: Resend ${res.status}: ${err}`)
+  }
+}
+
 // ── POST /api/motors/leads ─────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
@@ -105,6 +147,12 @@ export async function POST(req: NextRequest) {
     body = await req.json()
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  // Server-side consent enforcement — never trust the client
+  const consent = body.consent === 'true' || (body.consent as unknown) === true
+  if (!consent) {
+    return NextResponse.json({ error: 'Consent is required to submit this form' }, { status: 400 })
   }
 
   const firstName = body.firstName ?? ''
@@ -132,7 +180,8 @@ export async function POST(req: NextRequest) {
     (body.annualIncome
       ? `$${Math.round(Number(body.annualIncome) / 12).toLocaleString('en-CA')} CAD/mo`
       : '')
-  const message = (body.message ?? body.notes) || undefined
+  const message  = (body.message ?? body.notes) || undefined
+  const coSigner = body.coSigner || undefined
 
   const cleanPhone = phone.replace(/\s+/g, '')
 
@@ -144,10 +193,29 @@ export async function POST(req: NextRequest) {
     )
   }
 
+  // Collect sensitive PII fields and encrypt before KV write
+  const piiFields: Record<string, string> = {}
+  for (const k of [
+    'dob', 'sin', 'annualIncome', 'street', 'city', 'province', 'postalCode',
+    'timeAtAddress', 'employer', 'position', 'timeAtJob', 'maritalStatus',
+    'bankruptcy', 'repossession',
+  ]) {
+    if (body[k]) piiFields[k] = body[k]
+  }
+
+  let pii: string | undefined
+  if (Object.keys(piiFields).length > 0) {
+    try {
+      pii = encryptPII(JSON.stringify(piiFields))
+    } catch (err) {
+      console.warn('[motors/leads] PII encryption skipped (MOTORS_LEAD_ENCRYPTION_KEY not configured):', err instanceof Error ? err.message : err)
+    }
+  }
+
   const id: string = globalThis.crypto.randomUUID()
   const lead: MotorsLead = {
     id,
-    submittedAt: new Date().toISOString(),
+    submittedAt:     new Date().toISOString(),
     name,
     phone:           cleanPhone,
     email,
@@ -156,24 +224,31 @@ export async function POST(req: NextRequest) {
     creditRange,
     monthlyIncome,
     employmentStatus,
+    coSigner,
     message,
     status:          'new',
     source:          'credit-form',
     deliveryStatus:  'sent',
+    ...(pii ? { pii } : {}),
   }
 
   const redis = getRedis()
-  await redis.set(`motors:leads:${id}`, JSON.stringify(lead))
+  await redis.set(`motors:leads:${id}`, JSON.stringify(lead), { ex: LEAD_TTL_SECONDS })
   await redis.sadd('motors:leads:index', id)
 
   try {
-    await sendNotification(lead, body)
+    await sendAdminNotification(lead, body)
   } catch (err) {
-    console.error('[motors/leads] notification email failed:', err)
+    console.error('[motors/leads] admin notification failed:', err)
     await redis
-      .set(`motors:leads:${id}`, JSON.stringify({ ...lead, deliveryStatus: 'failed' }))
+      .set(`motors:leads:${id}`, JSON.stringify({ ...lead, deliveryStatus: 'failed' }), { ex: LEAD_TTL_SECONDS })
       .catch(() => {})
   }
+
+  // Customer receipt — non-blocking; failure does not affect lead save status
+  sendCustomerReceipt(lead).catch((err) => {
+    console.error('[motors/leads] receipt email fire-and-forget error:', err)
+  })
 
   return NextResponse.json({ success: true, id })
 }
@@ -195,7 +270,21 @@ export async function GET(req: NextRequest) {
   const leads = raw
     .map(r => {
       if (!r) return null
-      try { return typeof r === 'string' ? JSON.parse(r) : r } catch { return null }
+      try {
+        const lead: MotorsLead & Record<string, unknown> = typeof r === 'string' ? JSON.parse(r) : r
+        // Decrypt PII blob and merge fields into admin response
+        if (lead.pii) {
+          try {
+            const decrypted = JSON.parse(decryptPII(lead.pii as string)) as Record<string, string>
+            Object.assign(lead, decrypted)
+          } catch {
+            lead.piiDecryptError = true
+          }
+        }
+        return lead
+      } catch {
+        return null
+      }
     })
     .filter(Boolean)
     .sort((a: MotorsLead, b: MotorsLead) => b.submittedAt.localeCompare(a.submittedAt))

--- a/app/api/motors/leads/route.ts
+++ b/app/api/motors/leads/route.ts
@@ -3,6 +3,7 @@ import { Redis } from '@upstash/redis'
 import type { MotorsLead } from '@/types/inventory'
 import { checkPhoneRateLimit } from '@/lib/motors/ratelimit'
 import { encryptPII, decryptPII } from '@/lib/motors/encrypt'
+import { toE164 } from '@/lib/motors/phone'
 
 // 90-day TTL for pre-qualification leads (PIPEDA: retain only while purpose is active).
 // Funded deals must be migrated to the DMS before this window closes.
@@ -183,7 +184,10 @@ export async function POST(req: NextRequest) {
   const message  = (body.message ?? body.notes) || undefined
   const coSigner = body.coSigner || undefined
 
-  const cleanPhone = phone.replace(/\s+/g, '')
+  const cleanPhone = toE164(phone)
+  if (!cleanPhone) {
+    return NextResponse.json({ error: 'Please enter a valid Canadian or US phone number' }, { status: 400 })
+  }
 
   const allowed = await checkPhoneRateLimit(cleanPhone)
   if (!allowed) {

--- a/app/api/motors/leads/route.ts
+++ b/app/api/motors/leads/route.ts
@@ -47,7 +47,11 @@ async function sendAdminNotification(lead: MotorsLead, raw: Record<string, strin
   ]
 
   if (raw.dob)           lines.push(`Date of Birth:  ${raw.dob}`)
-  if (raw.sin)           lines.push(`SIN:            ${raw.sin}`)
+  if (raw.sin) {
+    const digits = raw.sin.replace(/\D/g, '')
+    const masked = digits.length >= 3 ? `•••-•••-${digits.slice(-3)}` : '•••-•••-•••'
+    lines.push(`SIN:            ${masked}  (full SIN encrypted — retrieve via admin panel)`)
+  }
   if (raw.maritalStatus) lines.push(`Marital Status: ${raw.maritalStatus}`)
 
   if (raw.street) {

--- a/app/api/motors/trade-in/route.ts
+++ b/app/api/motors/trade-in/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { Redis } from '@upstash/redis'
 import type { MotorsLead, MotorsLeadTradeIn } from '@/types/inventory'
 import { checkPhoneRateLimit } from '@/lib/motors/ratelimit'
+import { toE164 } from '@/lib/motors/phone'
 
 const RESEND_API = 'https://api.resend.com/emails'
 const TO_EMAIL   = 'roadhousesyndicate@gmail.com'
@@ -138,7 +139,10 @@ export async function POST(req: Request) {
   if (name.length  > 100) return NextResponse.json({ error: 'Name too long' },  { status: 400 })
   if (phone.length > 30)  return NextResponse.json({ error: 'Phone too long' }, { status: 400 })
 
-  const cleanPhone = phone.replace(/\s+/g, '')
+  const cleanPhone = toE164(phone)
+  if (!cleanPhone) {
+    return NextResponse.json({ error: 'Please enter a valid Canadian or US phone number' }, { status: 400 })
+  }
 
   const allowed = await checkPhoneRateLimit(cleanPhone)
   if (!allowed) {

--- a/app/motors/CLAUDE.md
+++ b/app/motors/CLAUDE.md
@@ -46,6 +46,7 @@
   trade-in/route.ts       ← POST (public); trade-in form → Resend; 60s KV rate limit/phone
   feed/route.ts           ← GET (Bearer CRON_SECRET) JSON + AAMVA XML export
   feed/catalog/route.ts   ← GET (Bearer CRON_SECRET) RFC 4180 CSV for FB Marketplace
+  fb-token-check/route.ts ← GET (Bearer CRON_SECRET) FB page token validity + expiry alert via Resend; daily cron
 ```
 
 ## KV keys
@@ -68,6 +69,17 @@ Vercel cron `0 15 * * *` (9am CST) → `POST /api/motors/sync`. Scrapes obrians.
 **Admin env vars:**
 - `MOTORS_ADMIN_SECRET` — gates the admin cookie auth and admin panel page read. Convention: `{ARM}_ADMIN_SECRET` (future arms: `CAPITAL_ADMIN_SECRET`, `STUDIO_ADMIN_SECRET`).
 - `CRON_SECRET` — gates machine endpoints (`/api/motors/sync` POST/GET, `/api/motors/feed`, `/api/motors/leads` GET, `/api/motors/leads/[id]` PATCH). Never shared with browser.
+
+**PII encryption env var:**
+- `MOTORS_LEAD_ENCRYPTION_KEY` — base64-encoded 32-byte AES-256-GCM key for credit app PII at rest. Generate: `openssl rand -base64 32`. Set in Vercel dashboard only — never commit. If unset, PII fields are not stored in KV (still delivered via email). See `docs/motors-credit-retention.md`.
+
+**Analytics env var:**
+- `NEXT_PUBLIC_META_PIXEL_ID` — Meta Pixel ID for motors subdomain. Set to your Pixel ID (e.g. `1234567890123456`). Fails silently if unset — no pixel fires.
+
+**FB token alert env vars (BATCH 4):**
+- `MOTORS_FB_PAGE_ACCESS_TOKEN` — copy of the FB_PAGE_ACCESS_TOKEN GitHub Secret, set in Vercel for the token-check cron.
+- `MOTORS_FB_APP_ID` + `MOTORS_FB_APP_SECRET` — Meta app credentials for debug_token expiry introspection.
+- `MOTORS_FB_ALERT_EMAIL` — address to receive token-expiry warnings (e.g. `roadhousesyndicate@gmail.com`).
 
 ## Constraints (permanent)
 

--- a/app/motors/layout.tsx
+++ b/app/motors/layout.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { REVIEWS, REVIEWS_ENABLED } from '@/lib/motors/reviews'
 import ScrollToTop from '@/components/motors/ScrollToTop'
+import MetaPixel from '@/components/motors/MetaPixel'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://motors.roadhouse.capital'),
@@ -95,8 +96,10 @@ function buildAutoDealer() {
 }
 
 export default function MotorsLayout({ children }: { children: React.ReactNode }) {
+  const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID
   return (
     <div className="min-h-screen bg-[#0A0A0A] text-white font-roboto flex flex-col">
+      {pixelId && <MetaPixel pixelId={pixelId} />}
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(buildAutoDealer()) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(organization) }} />
 

--- a/app/motors/vehicle/[vin]/page.tsx
+++ b/app/motors/vehicle/[vin]/page.tsx
@@ -212,6 +212,7 @@ export default async function VehicleDetailPage({ params }: PageProps) {
               firstSeenAt={vehicle.firstSeenAt}
               previousPrice={vehicle.previousPrice}
               priceDroppedAt={vehicle.priceDroppedAt}
+              currentPrice={vehicle.price}
             />
 
             {/* Spec table */}

--- a/app/motors/vehicle/[vin]/page.tsx
+++ b/app/motors/vehicle/[vin]/page.tsx
@@ -4,6 +4,7 @@ import VehicleGallery from '@/components/motors/VehicleGallery'
 import PaymentEstimator from '@/components/motors/PaymentEstimator'
 import StickyCallBar from '@/components/motors/StickyCallBar'
 import VehicleLeadForm from '@/components/motors/VehicleLeadForm'
+import PixelViewContent from '@/components/motors/PixelViewContent'
 import { getVehicleByVin, DEALER_ID } from '@/lib/motors/storage'
 import type { Vehicle } from '@/types/inventory'
 import ReviewCarousel from '@/components/motors/ReviewCarousel'
@@ -181,6 +182,7 @@ export default async function VehicleDetailPage({ params }: PageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd(vehicle)) }}
       />
 
+      <PixelViewContent vin={vin} name={vehicleLabel} price={vehicle.price} />
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 pb-24 space-y-10">
         {/* Breadcrumb */}
         <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm flex-wrap">

--- a/components/motors/CreditForm.tsx
+++ b/components/motors/CreditForm.tsx
@@ -335,7 +335,7 @@ export default function CreditForm() {
                         />
                         <p className="mt-1.5 text-gray-400 text-xs leading-relaxed">
                           Required by lenders to pull a credit bureau report. You can provide this later if preferred.
-                          Your SIN is encrypted and never shared without your knowledge.
+                          Your SIN is stored encrypted and used only for your credit bureau report.
                         </p>
                       </Field>
                     </div>

--- a/components/motors/CreditForm.tsx
+++ b/components/motors/CreditForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
+import { fbq } from '@/lib/motors/pixel'
 
 const provinces = [
   'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick',
@@ -187,6 +188,11 @@ export default function CreditForm() {
       setVehicleContext({ label: v, vin: vinParam })
       setForm((f) => ({ ...f, vehicleInterest: v || vinParam, vin: vinParam }))
     }
+    fbq('track', 'InitiateCheckout', {
+      content_category: 'credit-application',
+      ...(v ? { content_name: v } : {}),
+      ...(vinParam ? { content_ids: [vinParam] } : {}),
+    })
   }, [searchParams])
 
   const set = (key: keyof typeof form) =>
@@ -212,6 +218,11 @@ export default function CreditForm() {
         throw new Error(data.error ?? 'Submission failed')
       }
       setStatus('success')
+      fbq('track', 'Lead', {
+        content_category: 'credit-application',
+        ...(form.vehicleInterest ? { content_name: form.vehicleInterest } : {}),
+        ...(form.vin ? { content_ids: [form.vin] } : {}),
+      })
     } catch (err) {
       setStatus('error')
       setErrorMsg(err instanceof Error ? err.message : 'Something went wrong. Please try again.')

--- a/components/motors/CreditForm.tsx
+++ b/components/motors/CreditForm.tsx
@@ -167,6 +167,7 @@ export default function CreditForm() {
   const searchParams = useSearchParams()
   const [form, setForm] = useState({
     firstName: '', lastName: '', email: '', phone: '', dob: '', maritalStatus: '',
+    sin: '',
     street: '', city: '', province: 'Saskatchewan', postalCode: '', timeAtAddress: '',
     employmentStatus: '', employer: '', position: '', annualIncome: '', timeAtJob: '',
     downPayment: '', monthlyPayment: '', bankruptcy: '', repossession: '', creditRating: '', coSigner: '',
@@ -310,6 +311,23 @@ export default function CreditForm() {
                         </select>
                       </SelectWrapper>
                     </Field>
+                    <div className="sm:col-span-2">
+                      <Field label="Social Insurance Number (optional)">
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          value={form.sin}
+                          onChange={set('sin')}
+                          placeholder="XXX-XXX-XXX"
+                          maxLength={11}
+                          className={inputClass}
+                        />
+                        <p className="mt-1.5 text-gray-400 text-xs leading-relaxed">
+                          Required by lenders to pull a credit bureau report. You can provide this later if preferred.
+                          Your SIN is encrypted and never shared without your knowledge.
+                        </p>
+                      </Field>
+                    </div>
                   </div>
                 </section>
 

--- a/components/motors/MetaPixel.tsx
+++ b/components/motors/MetaPixel.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import Script from 'next/script'
+
+interface Props {
+  pixelId: string
+}
+
+export default function MetaPixel({ pixelId }: Props) {
+  return (
+    <Script id="meta-pixel" strategy="afterInteractive">{`
+      !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){
+      n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;
+      s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}
+      (window,document,'script','https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init','${pixelId}');fbq('track','PageView');
+    `}</Script>
+  )
+}

--- a/components/motors/PixelViewContent.tsx
+++ b/components/motors/PixelViewContent.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+import { fbq } from '@/lib/motors/pixel'
+
+interface Props {
+  vin: string
+  name: string
+  price?: number
+}
+
+// Fires Meta Pixel ViewContent on VDP mount. Renders nothing.
+export default function PixelViewContent({ vin, name, price }: Props) {
+  useEffect(() => {
+    fbq('track', 'ViewContent', {
+      content_ids:  [vin],
+      content_name: name,
+      content_type: 'vehicle',
+      ...(price && price > 0 ? { value: price, currency: 'CAD' } : {}),
+    })
+  }, [vin, name, price])
+  return null
+}

--- a/components/motors/VehicleGallery.tsx
+++ b/components/motors/VehicleGallery.tsx
@@ -15,14 +15,18 @@ const STATUS_STYLE: Record<Vehicle['status'], string> = {
 const SEVEN_DAYS_MS    = 7  * 24 * 60 * 60 * 1000
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
 
-function getMotionBadge(props: Pick<VehicleGalleryProps, 'firstSeenAt' | 'previousPrice' | 'priceDroppedAt'>): { label: string; className: string } | null {
+function getMotionBadge(props: Pick<VehicleGalleryProps, 'firstSeenAt' | 'previousPrice' | 'priceDroppedAt' | 'currentPrice'>): { label: string; className: string } | null {
   const now = Date.now()
 
   if (props.priceDroppedAt && props.previousPrice != null) {
     const age = now - new Date(props.priceDroppedAt).getTime()
     if (age <= FOURTEEN_DAYS_MS) {
+      const delta = props.currentPrice != null ? props.previousPrice - props.currentPrice : 0
+      const deltaStr = delta > 0
+        ? ` -$${new Intl.NumberFormat('en-CA').format(delta)}`
+        : ''
       return {
-        label: 'Price Reduced',
+        label: `Price Reduced${deltaStr}`,
         className: 'bg-[#C9922A]/20 text-[#F0C060] border border-[#C9922A]/40',
       }
     }
@@ -48,11 +52,12 @@ interface VehicleGalleryProps {
   firstSeenAt?:   string
   previousPrice?: number
   priceDroppedAt?: string
+  currentPrice?:  number
 }
 
-export default function VehicleGallery({ images, alt, status, firstSeenAt, previousPrice, priceDroppedAt }: VehicleGalleryProps) {
+export default function VehicleGallery({ images, alt, status, firstSeenAt, previousPrice, priceDroppedAt, currentPrice }: VehicleGalleryProps) {
   const [current, setCurrent] = useState(0)
-  const motionBadge = getMotionBadge({ firstSeenAt, previousPrice, priceDroppedAt })
+  const motionBadge = getMotionBadge({ firstSeenAt, previousPrice, priceDroppedAt, currentPrice })
   const total = images.length
   const src = images[current] ?? '/motors/rh-coming-soon.svg'
 

--- a/components/motors/VehicleLeadForm.tsx
+++ b/components/motors/VehicleLeadForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { fbq } from '@/lib/motors/pixel'
 
 interface VehicleLeadFormProps {
   vehicleInterest: string
@@ -39,6 +40,7 @@ export default function VehicleLeadForm({ vehicleInterest, vin }: VehicleLeadFor
       }
 
       setStatus('success')
+      fbq('track', 'Lead', { content_name: vehicleInterest, content_category: 'vehicle-inquiry' })
     } catch {
       setStatus('error')
       setErrorMsg('Connection error. Please call us at (306) 381-8222.')

--- a/docs/motors-counsel-001.md
+++ b/docs/motors-counsel-001.md
@@ -1,0 +1,422 @@
+# Motors Counsel Report — Session 001
+**Date:** 2026-06-12  
+**Scope:** `motors.roadhouse.capital` — O'Brian's Auto white-label inventory platform  
+**Process:** Repo-grounded audit across seven lanes. All findings cite actual file paths and line numbers. No assumptions.
+
+---
+
+## THE COUNSEL
+
+| Member | Lane | Primary Question |
+|---|---|---|
+| The Architect | Repo structure, routing, KV isolation, multi-dealer | Does this scale to dealer #2? |
+| The Hunter | Lead gen funnel: forms, Resend, conversion friction | Does a lead survive the pipe end-to-end? |
+| The Warden | Security, compliance, PII, rate limiting | What gets us burned? |
+| The Cartographer | SEO/geo surface, JSON-LD, sitemap, internal linking | Are we visible where buyers stand? |
+| The Herald | Social pipeline: FB/IG, catalog feed, FCAA linter, Reels | Is every unit broadcast, everywhere, correctly? |
+| The Appraiser | VDP completeness, vehicle data quality, pricing, trust | Would a buyer trust this listing? |
+| The Quartermaster | Analytics, measurement, cron health, cross-cutting glue | Is it actually working, and how would we know? |
+
+---
+
+## 1. THE ARCHITECT — Repo Structure & Multi-Dealer Readiness
+
+### Audit
+
+**Routing isolation** is clean. `proxy.ts` rewrites `motors.roadhouse.capital/*` → `/motors/*` before auth runs (proxy.ts:82–96). `/motors` and `/api/motors` are in the `FULLY_PUBLIC` array — no session, no bleed from the main RH auth system. The subdomain boundary is solid.
+
+**KV namespace** is appropriately scoped: all keys prefixed `motors:inventory:obrians:`, `motors:leads:`, `motors:index:obrians`. No cross-contamination with main RH KV keys.
+
+**DEALER_ID hardcoding** is the multi-dealer gap:
+
+- `lib/motors/storage.ts:4` — `export const DEALER_ID = 'obrians'` (module-level global)
+- Imported and used directly in: `app/motors/inventory/page.tsx:3,164`, `app/motors/vehicle/[vin]/page.tsx:7,23,160`, `app/motors/used/page.tsx:3,68`, `app/api/motors/sync/route.ts:6`, `app/api/motors/feed/route.ts:2`, `app/api/motors/feed/catalog/route.ts:2`
+
+Storage functions in `lib/motors/storage.ts:13–123` **do** accept a `dealer_id` parameter — the function layer is multi-dealer ready. The application layer is not. Adding dealer #2 would require:
+
+1. Promoting `DEALER_ID` from global export to request-scoped context (subdomain → dealer map in proxy.ts or a new `lib/motors/context.ts`)
+2. Threading that context into 6 API routes + 2 page server components
+3. Merging `multi-dealer-wip` (4 commits ahead, contains `lib/motors/storage-multi.ts` — **do not touch until scoped**)
+
+**`FilterBar.tsx`** is noted in CLAUDE.md as potentially superseded by `FilterSidebar.tsx`. `FilterBar.tsx` exists in `components/motors/` and should be verified as dead code before removal — risk of implicit import elsewhere.
+
+**Scraper coupling:** `lib/motors/scraper.ts` is tightly coupled to obrians.ca's Webflow CMS structure (`#listing-info` div attributes, `jetboost-list-item` class, `VEHICLE_CDN = '620fb02195ca806649283a5d'`). A second dealer on a different CMS would require a new scraper module — acceptable, but the normalized output schema (`types/inventory.ts`) is the correct abstraction layer and should remain dealer-agnostic.
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| A1 | Extract dealer context from subdomain in proxy.ts → inject `x-dealer-id` request header; consume in API routes | M | 5 — unblocks multi-dealer without branch merge |
+| A2 | Confirm `FilterBar.tsx` is dead code; remove it | S | 2 — hygiene |
+| A3 | Add `motors:health:{dealer}` KV key written on each sync (timestamp + count) for status dashboards | S | 3 — enables Quartermaster goals |
+| A4 | Document scraper abstraction contract: `Scraper` interface with `fetchSlugs()` + `parseListing()` signatures so dealer #2 implements the same contract | S | 3 — architectural clarity |
+
+### Biggest Risk
+
+`multi-dealer-wip` exists. If that branch is ever carelessly merged or cherry-picked without a scoping session, it will silently break production DEALER_ID routing for O'Brian's. The CLAUDE.md warning is the only guard.
+
+---
+
+## 2. THE HUNTER — Lead Gen Funnel
+
+### Audit
+
+Three distinct lead types, three distinct form components, three distinct API routes.
+
+**Form field coverage:**
+
+| Form | Component | Key Fields | API Route |
+|---|---|---|---|
+| Vehicle Inquiry | `VehicleLeadForm.tsx` | name, phone, vehicleInterest (opt), vin (opt) | `POST /api/motors/lead` |
+| Credit Pre-Qual | `CreditForm.tsx` | 26 fields: full identity, address, employment, income, credit history, co-signer, trade-in | `POST /api/motors/leads` |
+| Trade-In / Sell | `TradeInForm.tsx` | 14 fields: vehicle details, condition, ownership, name, phone, email | `POST /api/motors/trade-in` |
+
+**Data destination:** All three routes write to KV (`motors:leads:{uuid}`, indexed in `motors:leads:index`) AND send a Resend email to `roadhousesyndicate@gmail.com`. Double redundancy — good.
+
+**Admin panel** (`/motors/admin`) displays all leads with status management (new → contacted → approved → closed → dead), source badges, and email delivery status. The funnel has a home.
+
+**Drop-off points identified:**
+
+1. **VehicleLeadForm: name-only, no email.** A missed call means the lead is unrecoverable — phone is the only contact field and it's a free-text input (max 30 chars, not validated to E.164 or 10-digit). A transposed digit = lost lead.
+2. **Credit form email field is required on the backend** (`leads/route.ts:117`) but appears optional in the UI — users may skip it, hit a vague 400, and abandon.
+3. **No form-level success state guidance** — after submit, user sees generic confirmation with no "what happens next" copy. No email confirmation sent to the submitter.
+4. **Trade-in form has no follow-up path.** It captures the vehicle but doesn't prompt the user toward a specific inventory unit or credit pre-qual CTA.
+5. **No email back to the lead** — the Resend call only fires outbound to the dealer, never to the customer. No "we got your inquiry" receipt.
+6. **PaymentEstimator CTA** (`/motors/credit?vin={vin}&v={label}`) pre-fills the credit form correctly — this is a strong funnel linkage. But the term/rate selections don't survive the navigation (no query param pass-through to CreditForm).
+7. **Admin leads panel has no pagination** (`AdminPanel.tsx:88` iterates all leads). With 100+ leads this already degrades; at 500+ it will be slow.
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| H1 | Add email field to VehicleLeadForm (optional) + send customer receipt email on all three forms via Resend | S | 5 — single biggest funnel improvement |
+| H2 | Validate phone to 10+ digits on VehicleLeadForm (client + server) | S | 3 — recovers transposed-digit leads |
+| H3 | Thread PaymentEstimator term/rate params into credit form pre-fill | S | 3 — reduces friction at highest-intent entry point |
+| H4 | Add trade-in form CTA: "Browse our inventory while we review your trade" → `/motors/inventory` | S | 2 — captures mid-funnel attention |
+| H5 | Paginate admin leads panel (server-side, 20/page) | M | 2 — operational scalability |
+
+### Biggest Risk
+
+No customer-side confirmation email. A lead submits their credit app — income, DOB, bankruptcy history — and receives zero acknowledgment. That's a trust cliff. If the Resend outbound also silently fails (email delivery logged as error but no retry), the lead simply vanishes. Both problems are one Resend call away from being fixed.
+
+---
+
+## 3. THE WARDEN — Security & Compliance
+
+### Audit
+
+**Rate limiting:** `lib/motors/ratelimit.ts` applies a 60-second per-phone window across all three form endpoints. The mechanism is correct but has a critical fail-open flaw: `catch { return true }` (line 24) — if Upstash KV is unreachable, all rate limiting is bypassed. Should be `return false` (deny on KV failure).
+
+**Bot protection:** None. No honeypot fields, no CAPTCHA, no Cloudflare Turnstile. The only protection is per-phone rate limiting. A bot with rotating phone numbers submits unlimited credit applications with synthetic PII. Given what the credit form stores (DOB, income, bankruptcy status), this is a meaningful abuse vector.
+
+**Admin auth (CSRF):** `POST /api/motors/admin/auth` accepts `token` as a form field with no CSRF token validation. An attacker-controlled page can silently POST to this endpoint from a victim's browser session. The cookie is `httpOnly` and `secure` in production — the CSRF issue affects the auth endpoint itself, not the session cookie.
+
+**PII at rest:** The credit form stores to KV plaintext: full name, email, phone, DOB, marital status, full address, time at address, employer, position, annual income, monthly payment, bankruptcy status, repossession history, credit rating, co-signer details. Upstash Redis provides TLS in transit but no encryption at rest on standard plans. Saskatchewan's *Personal Information Protection and Electronic Documents Act* (PIPEDA federal + provincial analog) requires reasonable safeguards — "plaintext in Redis" is defensible under current law but creates liability on breach.
+
+**Consent field not enforced server-side:** `CreditForm.tsx:477` has a UI consent checkbox. `app/api/motors/leads/route.ts:102–179` does not validate that `consent === true` before accepting the submission. A direct POST bypasses the consent gate entirely.
+
+**PII retention:** No TTL on `motors:leads:{id}` keys. Leads accumulate indefinitely. No deletion workflow, no retention policy documented.
+
+**FCAA compliance (Saskatchewan dealer rules):** The `compliance.py` linter covers banned superlatives and financing claim language. The 31-test suite (`tests/test_compliance.py`) is solid. However, **the linter only runs on social media captions** — it does not run on VDP descriptions, hero section copy, or any on-site text. If a salesperson edits the site copy with a "Best Price!" claim, the linter won't catch it.
+
+**Deferred from prior security sprint** (per `security_audit_2026-06-10.md` memory): H4 wallet session auth and H5 ADMIN_WALLETS affect the main app, not motors. No open motors-specific deferred items from that sprint.
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| W1 | Fix rate limit fail-open: `catch { return false }` in `lib/motors/ratelimit.ts:24` | S | 4 — closes availability bypass |
+| W2 | Add honeypot field (hidden `website` input) to all three forms; reject server-side if populated | S | 3 — deters naive bots |
+| W3 | Validate `consent: true` server-side before storing credit app (`leads/route.ts`) | S | 4 — PIPEDA defensibility |
+| W4 | Add 90-day TTL to `motors:leads:{id}` KV keys (or an explicit archival workflow) | M | 3 — reduces breach liability surface |
+| W5 | Add CSRF double-submit cookie pattern to admin auth route | M | 3 — closes CSRF on admin login |
+
+### Biggest Risk
+
+Unconstrained credit application storage with no retention policy. Saskatchewan's privacy regime requires leads to be held only as long as necessary for the stated purpose. A breach of the current KV dataset exposes DOB, income, bankruptcy, and employer data for every person who submitted a credit app since launch — with no deletion mechanism and no encryption at rest. This is the single highest-severity liability item in the entire motors arm.
+
+---
+
+## 4. THE CARTOGRAPHER — SEO & Geo Surface
+
+### Audit
+
+**JSON-LD coverage is strong:**
+
+| Page | Schemas Present |
+|---|---|
+| `app/motors/layout.tsx` (sitewide) | `AutoDealer`, `Organization` |
+| `app/motors/vehicle/[vin]/page.tsx` | `Car` (brand, model, VIN, itemCondition, mileage, offers, seller), `BreadcrumbList` (3-level) |
+| `app/motors/inventory/page.tsx` | `ItemList` (dynamically generated) |
+| `app/motors/used/page.tsx` | `LocalBusiness` per city |
+| `app/motors/[city]/page.tsx` | `LocalBusiness` per city |
+
+**Notable absences:**
+- **`FAQPage` schema** — no FAQ structured data on any page. Credit, trade-in, and financing questions are common vehicle buyer queries with strong local search intent.
+- **`AggregateRating` schema** — conditionally added to `AutoDealer` only when `REVIEWS_ENABLED` is true (`layout.tsx:78`) and review count ≥ 3. Currently not live (feature-flagged off).
+- **`Event` schema** — no schema for sales events, promotions.
+
+**VDP metadata** (`vehicle/[vin]/page.tsx:21–59`): Dynamic title (year + make + model + trim), dynamic description with specs, explicit `alternates.canonical`, OG image via `opengraph-image.tsx` convention. This is correctly implemented.
+
+**Sold vehicles** return `<SoldVehiclePage>` with `robots: 'noindex'` — correct. No hard 404, no dead URLs in sitemap.
+
+**Geo pages** (`[city]/page.tsx`): Saskatoon, Regina, Prince Albert, Moose Jaw — four cities served. `LocalBusiness` schema per page with city-specific content. The `used/page.tsx` hub links to all four geo pages (internal linking is present). However, the geo pages are only four cities. Saskatchewan has meaningful car-buyer populations in Lloydminster, Swift Current, North Battleford, Yorkton, and Estevan that are not served by dedicated pages.
+
+**Sitemap** (`app/motors/sitemap.ts` exists): Content not audited in this session — should be verified to include all VINs, geo pages, and key static pages, and exclude sold vehicles and admin routes.
+
+**Internal linking gaps:**
+- VDP pages do not cross-link to related vehicles (same make, same price range, same body type). Each VDP is a dead end after the lead form.
+- No "Browse all [Make] vehicles" link from a VDP back to a filtered inventory view.
+- City pages do not link to specific makes popular in that market.
+
+**Title tag pattern** on inventory page: not audited (server component, dynamic). Should include city/province context for local search.
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| C1 | Add `FAQPage` JSON-LD to credit page and trade-in page with 3–5 common financing/trade-in questions | S | 4 — captures financing-intent queries |
+| C2 | Add "Similar Vehicles" section to VDP: same make OR same price range ±$5k, max 4 cards | M | 4 — reduces bounce, increases pages/session |
+| C3 | Expand geo pages to Lloydminster, Swift Current, North Battleford, Yorkton (copy-gen is cheap with LLM) | M | 3 — incremental Saskatchewan coverage |
+| C4 | Audit and verify `sitemap.ts`: all VINs included, sold excluded, geo pages included, admin excluded | S | 3 — GSC indexation health |
+| C5 | Enable `AggregateRating` schema once ≥ 3 Google reviews are collected | S | 4 — rich snippet eligibility for dealer searches |
+
+### Biggest Risk
+
+No cross-VDP internal linking. Every vehicle detail page is an island. A visitor who doesn't convert on one unit has no algorithmic nudge to the next. This is both an SEO problem (shallow crawl depth, low pages/session signal) and a conversion problem. "Similar Vehicles" is the single highest-leverage SEO/UX addition.
+
+---
+
+## 5. THE HERALD — Social Pipeline
+
+### Audit
+
+**Pipeline health is good.** 335+ vehicles posted since May 9, 2026. `posted.json` shows 100% success rate on sampled entries. The GitHub Actions workflow fires at 9am CST daily, posts 6 vehicles per run to FB + IG, commits `posted.json` back with `[skip ci]`, and manages the token lifecycle with a 14-day expiry warning.
+
+**FCAA compliance linter** (`compliance.py`) is mature: covers banned superlatives, urgency language, and illegal financing claims. 31 tests. This is above-average for a dealer of this size.
+
+**Platform differentiation:** Captions are generated platform-specifically via Claude (`claude-opus-4-6`). `--auto-theme` generates thematic variation per run. This is correct.
+
+**FB Marketplace catalog feed** (`/api/motors/feed/catalog/route.ts`): RFC 4180 CSV with 27 columns. Drivetrain column is always empty (by design, not scraped from obrians.ca). The feed is gated by `CRON_SECRET` — it must be pulled externally to surface on Marketplace. Whether Facebook is actually consuming this feed regularly is unknown (no instrumentation).
+
+**Reels pipeline status:**
+- `reels.py` publishes Ken Burns-style 9:16 MP4 to **Facebook Reels** — this works.
+- **Instagram Reels is blocked** (error 2207076) — needs a public video URL. `reels.py` requires Vercel Blob. This is M3 TODO #17 in `app/motors/CLAUDE.md`.
+- `ENABLE_REELS=true` in GitHub vars, `--reels-only` flag exists. One vehicle has a `reel_posted_at` entry in `posted.json`.
+
+**Token health:** `check_fb_token()` warns at 14 days before expiry but there is no automated renewal path. When the token expires, the daily run silently fails. The only notification is a warning log in GitHub Actions output.
+
+**Caption quality control:** No A/B testing of caption variants. No engagement feedback loop — the pipeline generates and posts but never reads back reach, saves, or shares to improve future prompts. Claude generates captions cold every run with no signal about which styles performed.
+
+**`posted.json` as audit trail:** 1385 lines committed to the repo. This works but will grow unboundedly. At 6 posts/day, the file will hit 10,000+ entries in ~4.5 years — manageable but worth planning a rotation strategy eventually.
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| He1 | Implement Vercel Blob upload in `PUT /api/motors/reels/upload` to unblock IG Reels (M3 TODO #17) | M | 5 — extends reach to IG Reels audience |
+| He2 | Add FB Insights API read-back after 48h: fetch reach/engagement for recent posts, append to `posted.json`, use top-3 captions as few-shot examples in next Claude prompt | L | 4 — closes the feedback loop; improves caption quality over time |
+| He3 | Add Slack/email alert when `FB_PAGE_ACCESS_TOKEN` expires or any run produces zero successful posts | S | 3 — operational awareness |
+| He4 | Verify Facebook Marketplace catalog feed is actually being consumed: check catalog manager in Meta Business Suite, confirm `feed/catalog` route is being polled | S | 3 — may reveal silent failure |
+| He5 | Archive `posted.json` entries older than 180 days into `posted_archive_YYYY.json` to keep the active file lean | S | 1 — hygiene |
+
+### Biggest Risk
+
+FB token expiry with no automated alerting to the non-technical operator. The daily post run silently produces zero output. O'Brian's (or Dalton) would only notice if they check the Facebook page manually. A missed week of posts during peak selling season (spring/summer) costs real leads. A 14-day warning log in GitHub Actions output is not an operational alert.
+
+---
+
+## 6. THE APPRAISER — Vehicle Data & VDP
+
+### Audit
+
+**Vehicle schema** (`types/inventory.ts:3–28`):
+
+Present fields: `vin`, `stock_number`, `year`, `make`, `model`, `trim`, `body_style`, `mileage`, `price`, `msrp` (opt), `status`, `images[]`, `fuel_type`, `transmission`, `exterior_color`, `interior_color`, `features[]`, `description` (opt), `updated_at`, `firstSeenAt` (opt), `previousPrice` (opt), `priceDroppedAt` (opt).
+
+**Missing fields (by design or gap):**
+
+| Field | Status | Impact |
+|---|---|---|
+| `drivetrain` (2WD/AWD/4WD) | Not scraped from obrians.ca — documented gap | High — top filter criteria for SK buyers |
+| Engine displacement / cylinders | Not captured | Medium |
+| Horsepower / torque | Not captured | Low — relevant for truck/performance buyers |
+| Safety ratings (NHTSA/IIHS) | Not captured | Medium — trust signal |
+| Warranty info (remaining OEM) | Not captured | High — used vehicle differentiator |
+| Service history / # of owners | Not captured | High — trust signal |
+| Days on lot | Derivable from `firstSeenAt` but not surfaced on VDP | Medium |
+
+**`msrp` vs `price`:** `msrp` is optional. When present, savings could be displayed ("Save $X vs MSRP"). Currently unused on VDP — confirmed by absence of savings display in component audit. This is low-effort, high-trust-signal improvement.
+
+**`previousPrice` / `priceDroppedAt`:** Price drop data is scraped and stored but **not surfaced on VDP or inventory grid**. "Price Reduced" badges are a proven conversion driver.
+
+**PaymentEstimator** (`components/motors/PaymentEstimator.tsx`):
+- Rate tiers: Prime 4.99% → Sub-Prime 19.99% (5 tiers)
+- Terms: 36/48/60/72/84 months
+- Output: bi-weekly + monthly payment
+- Doc fee: hardcoded constant from `lib/motors/payments.ts`
+- **FCAA note:** Payment estimates are on-site, not in social captions. FCAA rules on advertising financing terms apply to advertising, not necessarily an on-site calculator with disclosures — but the calculator should have a disclaimer ("OAC — On Approved Credit. Rate varies by credit profile."). Auditing whether this disclaimer is present was not completed in this session.
+
+**VDP completeness:** Strong. Gallery, specs table, PaymentEstimator, VehicleLeadForm, TradeInBanner, StickyCallBar, optional ReviewCarousel. The page has all the conversion elements. The trust gap is data completeness (no warranty, no history) and no social proof beyond the feature-flagged ReviewCarousel.
+
+**Images:** `next/image` with `unoptimized` prop throughout (`VehicleImage.tsx`, per CLAUDE.md constraint). Fallback to `rh-coming-soon.svg` on error. Watermark (30% opacity RH logo) applied in social posts, not on site. Image load failure on VDP is gracefully handled.
+
+**Stale / sold units:** `status: 'sold'` renders `SoldVehiclePage` with `noindex`. No stale-unit detection (e.g., units not updated in >14 days that are still `available`). The sync runs daily at 9am CST — staleness window is max 24 hours under normal conditions.
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| Ap1 | Surface `previousPrice` / `priceDroppedAt` as "Price Reduced" badge on `VehicleCard.tsx` and VDP hero | S | 5 — proven conversion driver, data already exists |
+| Ap2 | Display `msrp` vs `price` savings on VDP when `msrp` is present | S | 3 — trust signal at zero data cost |
+| Ap3 | Add "OAC" disclaimer to PaymentEstimator output (verify if missing) | S | 4 — FCAA compliance for financing display |
+| Ap4 | Add "Days on lot" display derived from `firstSeenAt` — subtle trust signal for fresh inventory | S | 2 — low effort |
+| Ap5 | Investigate drivetrain extraction from obrians.ca listing detail pages (may be in page body, not `#listing-info`) | M | 5 — top filter missing for SK winter-driving buyers |
+
+### Biggest Risk
+
+Price drop data is being scraped and stored (`previousPrice`, `priceDroppedAt` in the Vehicle schema) but not shown to the buyer. This is a free conversion signal being left on the table. Buyers who see a price reduction are more likely to act — and the data is already there.
+
+---
+
+## 7. THE QUARTERMASTER — Measurement, Glue & Cross-Cutting
+
+### Audit
+
+**Analytics: zero.** Grepped across all `app/motors/` and `components/motors/` files for `gtag`, `GA4`, `_fbq`, `posthog`, `mixpanel`, `dataLayer`, `analytics`. Zero hits. The motors subdomain has no page view tracking, no conversion events, no traffic source attribution, no funnel analytics of any kind. `app/motors/layout.tsx` has no `<Script>` tags beyond JSON-LD.
+
+**What this means in practice:**
+- No GSC integration verification for motors subdomain (is `motors.roadhouse.capital` separately verified in Search Console?)
+- No way to know which geo pages or VDPs drive the most traffic
+- No way to know which form (vehicle inquiry vs credit vs trade-in) converts best
+- No way to attribute leads to traffic source (organic, social, direct)
+- No way to measure bounce rate, session depth, or time-on-VDP
+- No way to A/B test anything
+
+**Cron health monitoring** (`app/api/motors/sync/route.ts`):
+- Two alerting tripwires: >5 scrape errors OR >20% inventory drop → email to `ALERT_EMAIL`
+- Structured JSON logging (`evt: 'motors.sync.scraper_fatal'`) — correct format for Vercel log drain
+- No monitoring for cron not-firing (silent cron failure is undetected)
+- `GET /api/motors/sync` (CRON_SECRET) returns current inventory count — useful for polling
+
+**Social pipeline instrumentation** (`ops/motors-social/`):
+- `posted.json` serves as a basic audit trail (VIN, timestamps, success flags)
+- No engagement metrics stored (reach, impressions, reactions)
+- GitHub Actions stdout captures run logs but they aren't persisted anywhere accessible
+
+**API route logging:**
+- `console.error` used in lead routes for email send failures — correct (structured)
+- No request-level logging (no access log, no latency recording, no lead submission count)
+- No way to know how many lead submissions fail vs succeed across the API
+
+**Admin panel audit trail:** No record of who accessed the admin panel, when, or what status changes were made. With CRON_SECRET as the only auth gate, all access looks identical in logs.
+
+**Env var hygiene:**
+- `MOTORS_ADMIN_SECRET` and `CRON_SECRET` are correctly in Vercel env, not in code
+- `ALERT_EMAIL` referenced in sync route but not listed in CLAUDE.md env var table — may need documentation
+- `ENABLE_REELS` is a GitHub Vars entry, not a Vercel env var — fine for GH Actions context but worth noting the separation
+
+**Cross-cutting debt left by other counsel members:**
+- No IP-level rate limiting (Warden flagged per-phone only)
+- No customer receipt email (Hunter flagged)
+- No pagination on admin leads (Hunter flagged)
+- FB token expiry alerting (Herald flagged)
+- Sitemap audit pending (Cartographer flagged)
+
+### Proposals
+
+| # | Proposal | Effort | Impact |
+|---|---|---|---|
+| Q1 | Install Meta Pixel on motors subdomain (`layout.tsx`): PageView, ViewContent (VDP), Lead (form submit), InitiateCheckout (PaymentEstimator). This also feeds FB ad targeting. | S | 5 — baseline funnel visibility + retargeting pool |
+| Q2 | Add GA4 (or Plausible for privacy) to motors subdomain: page views, scroll depth, form submit events | S | 5 — organic search visibility, funnel analysis |
+| Q3 | Verify `motors.roadhouse.capital` is separately verified in Google Search Console (root domain alone does not cover subdomain) | S | 4 — GSC coverage gap |
+| Q4 | Add `/api/motors/status` endpoint (CRON_SECRET) returning cron last-run time, inventory count, lead count (last 7d), and social last-post VIN — health dashboard primitive | S | 3 — operational visibility |
+| Q5 | Add cron not-firing detection: if `motors:health:{dealer}` KV key is >25 hours old, send alert email on next cold request | M | 3 — silent cron failure is currently undetected |
+
+### Biggest Risk
+
+Zero analytics means zero accountability for the platform's effectiveness. O'Brian's (the dealer) has no evidence of how many people visit, browse, or submit leads through this platform — which makes it impossible to justify the relationship, price the service, or optimize for growth. Adding Meta Pixel alone (Q1) costs one afternoon and immediately enables retargeting, attribution, and funnel data.
+
+---
+
+## COUNSEL DEBATE — Conflicts, Overlaps, Dependencies
+
+### Conflicts
+- **Cartographer (C3: more geo pages)** vs **Quartermaster (no analytics)**. Expanding geo pages without analytics means no way to measure which cities convert. Defer C3 until Q2 (GA4) is live.
+- **Appraiser (Ap5: drivetrain scraping)** vs **Architect scope**. Drivetrain extraction requires scraper changes that could conflict with `multi-dealer-wip`. Tag as "after multi-dealer merge."
+
+### Overlaps
+- **Hunter (H1: customer receipt email)** and **Warden (W3: consent enforcement)** both touch `app/api/motors/leads/route.ts`. Should be a single PR.
+- **Warden (W1: rate limit fix)** and **Hunter (H2: phone validation)** both touch `lib/motors/ratelimit.ts` + form validation. Same PR.
+- **Herald (He3: FB token alerting)** and **Quartermaster (Q4: status endpoint)** both want operational health visibility. A single `/api/motors/status` endpoint + Slack webhook covers both.
+
+### Unlock Dependencies
+```
+Q1 (Meta Pixel)   → unlocks retargeting for any paid social O'Brian's runs
+Q2 (GA4)          → unlocks C3 (geo expansion with data) and funnel analysis for H-series fixes
+Q3 (GSC subdomain)→ unlocks Cartographer baseline; should be first action taken
+Ap1 (price drop)  → unlocks higher-conversion inventory grid; zero data work needed
+W1 (rate fix)     → should ship before any social/paid traffic is driven
+He1 (IG Reels)    → highest reach expansion; depends on Vercel Blob setup
+```
+
+---
+
+## VERDICT — Unified Roadmap
+
+### Milestone 1 — NOW (Low effort, high impact, no dependencies)
+Hardening and quick wins. Ship these as a single sprint.
+
+| Rank | Item | Council Member | Effort | Impact | Why Now |
+|---|---|---|---|---|---|
+| 1 | Meta Pixel (PageView, ViewContent, Lead, InitiateCheckout) | Quartermaster Q1 | S | 5 | Zero analytics is zero accountability; enables retargeting immediately |
+| 2 | Price drop badges on VehicleCard + VDP | Appraiser Ap1 | S | 5 | Data already in KV; pure display change; proven conversion driver |
+| 3 | GSC subdomain verification | Quartermaster Q3 | S | 4 | Motors subdomain may not be indexed under root GSC property |
+| 4 | Customer receipt email + consent enforcement | Hunter H1 + Warden W3 | S | 4+4 | Single PR; closes PII consent gap + trust cliff in one shot |
+| 5 | Rate limit fail-open fix + phone validation | Warden W1 + Hunter H2 | S | 4+3 | Same file; KV-down = open door is unacceptable with credit app data in KV |
+
+### Milestone 2 — NEXT (Medium effort, structural improvements)
+Funnel depth + SEO substance + operational visibility.
+
+| Rank | Item | Council Member | Effort | Impact | Why Next |
+|---|---|---|---|---|---|
+| 6 | GA4 (or Plausible) on motors subdomain | Quartermaster Q2 | S | 5 | Requires pixel first (M1); enables all funnel analysis |
+| 7 | FAQ JSON-LD on credit + trade-in pages | Cartographer C1 | S | 4 | Captures financing-intent queries; Saskatchewan dealer FAQ is low competition |
+| 8 | Similar Vehicles on VDP | Cartographer C2 | M | 4 | Reduces bounce, increases crawl depth; no data work |
+| 9 | FB token expiry alert + `/api/motors/status` health endpoint | Herald He3 + Quartermaster Q4 | S | 3+3 | Single PR; operational visibility that currently doesn't exist |
+| 10 | Honeypot fields + admin CSRF fix | Warden W2 + W5 | S | 3+3 | Bot/CSRF hardening before paid traffic drives volume |
+
+### Milestone 3 — LATER (Larger scope, dependencies, or external blockers)
+Platform expansion and reach.
+
+| Item | Council Member | Effort | Dependency |
+|---|---|---|---|
+| IG Reels unblock (Vercel Blob) | Herald He1 | M | M3 TODO #17; Vercel Blob setup |
+| PaymentEstimator term/rate pre-fill from VDP | Hunter H3 | S | None — but low urgency vs M1/M2 |
+| Lead PII 90-day retention TTL | Warden W4 | M | Legal review of retention policy |
+| Drivetrain field investigation + extraction | Appraiser Ap5 | M | Post multi-dealer-wip merge |
+| Expand geo pages (4 additional SK cities) | Cartographer C3 | M | GA4 data to prioritize cities |
+| Engagement feedback loop for Claude captions | Herald He2 | L | FB Insights API access |
+| Admin leads pagination | Hunter H5 | M | Low urgency at current lead volume |
+| `AggregateRating` schema (needs ≥3 reviews) | Cartographer C5 | S | Requires Google reviews |
+
+---
+
+## TOP 10 TABLE
+
+| Rank | Title | Lane | Effort | Impact | Milestone |
+|---|---|---|---|---|---|
+| 1 | Meta Pixel on motors subdomain | Quartermaster | S | 5 | Now |
+| 2 | Price drop badges ("Price Reduced") on VehicleCard + VDP | Appraiser | S | 5 | Now |
+| 3 | GSC subdomain verification for motors.roadhouse.capital | Quartermaster | S | 4 | Now |
+| 4 | Customer receipt email + server-side consent enforcement | Hunter + Warden | S | 4 | Now |
+| 5 | Rate limit fail-closed + phone E.164 validation | Warden + Hunter | S | 4 | Now |
+| 6 | GA4 / Plausible analytics on motors subdomain | Quartermaster | S | 5 | Next |
+| 7 | FAQ JSON-LD on credit + trade-in pages | Cartographer | S | 4 | Next |
+| 8 | Similar Vehicles section on VDP | Cartographer | M | 4 | Next |
+| 9 | FB token expiry alert + `/api/motors/status` health endpoint | Herald + Quartermaster | S | 3 | Next |
+| 10 | Honeypot fields + admin auth CSRF fix | Warden | S | 3 | Next |
+
+---
+
+*Generated: 2026-06-12 — motors-counsel-001. No code changes made in this session.*

--- a/docs/motors-credit-retention.md
+++ b/docs/motors-credit-retention.md
@@ -1,0 +1,86 @@
+# RoadHouse Motors — Credit Application Data Retention Policy
+
+**Entity:** Praetorian Holdings Corp. (DL331386) · Saskatchewan  
+**Effective:** 2026-06-12  
+**Applies to:** Pre-qualification lead submissions via `motors.roadhouse.capital/credit`
+
+---
+
+## What we collect
+
+When you submit a pre-qualification form we collect:
+
+| Field | Purpose |
+|---|---|
+| Name, email, phone | Contact and identity |
+| Date of birth | Required by lenders for identity verification |
+| Social Insurance Number (if provided) | Required by lenders to pull a credit bureau report |
+| Home address | Required by lenders; part of bureau inquiry |
+| Employment status, employer, income | Lender underwriting criteria |
+| Bankruptcy / repossession history | Lender risk assessment |
+| Credit self-rating, down payment, co-signer | Pre-qualification routing |
+| Vehicle of interest | Matching to inventory |
+
+Collection authority: your explicit consent checkbox on the form, as required by PIPEDA.
+
+---
+
+## How we store it
+
+**Non-sensitive fields** (name, phone, email, employment category, credit tier, vehicle interest) are stored as plain JSON in Vercel KV (Upstash Redis).
+
+**Sensitive PII fields** (DOB, SIN, address, employer details, income, bankruptcy/repo flags) are encrypted using AES-256-GCM before being written to KV. The encryption key is held in Vercel's encrypted environment variable store (`MOTORS_LEAD_ENCRYPTION_KEY`) and is never logged or committed to source control.
+
+All lead data is also delivered to the dealer's notification email inbox (roadhousesyndicate@gmail.com) via Resend for immediate review.
+
+---
+
+## Retention window
+
+**90 days** from the date of submission.
+
+After 90 days, the KV entry expires automatically via Redis TTL. The lead ID remains in the index set but resolves to null on read.
+
+**Rationale:** PIPEDA requires personal information to be retained only as long as necessary for the identified purpose. The purpose of a pre-qualification form is to evaluate financing eligibility — a decision typically reached within 1–2 business days. 90 days provides adequate buffer for follow-up conversations and slower approval pipelines while avoiding indefinite retention of sensitive financial data.
+
+**Note for funded deals:** If an application results in a financed transaction, the complete deal file must be transferred to your Dealer Management System (DMS) before the 90-day KV window closes. DMS retention follows CRA requirements (7 years for financial transaction records). This KV store is intake-only and is not a substitute for proper DMS record-keeping.
+
+---
+
+## Override conditions
+
+If a lender stipulation or provincial regulation requires a longer retention period for denied applications (e.g., 1 year), set `LEAD_TTL_SECONDS` in `app/api/motors/leads/route.ts` to `31536000` (365 days). Document the reason in a code comment. Any change must be reviewed by the dealer principal.
+
+---
+
+## Access
+
+Lead data is accessible only through:
+
+1. **Admin panel** (`/motors/admin`) — authenticated with `MOTORS_ADMIN_SECRET` httpOnly cookie
+2. **Machine endpoint** (`GET /api/motors/leads`) — authenticated with `CRON_SECRET` bearer token
+
+No lead data is exposed to the browser or unauthenticated requests. PII fields are decrypted server-side only during admin reads.
+
+---
+
+## Your rights
+
+Under PIPEDA, you may request access to, correction of, or deletion of your personal information by contacting us at:
+
+- **Email:** roadhousesyndicate@gmail.com  
+- **Phone:** (306) 381-8222  
+- **Address:** Saskatchewan, Canada
+
+Requests are processed within 30 days.
+
+---
+
+## Encryption key rotation
+
+To rotate the `MOTORS_LEAD_ENCRYPTION_KEY`:
+
+1. Generate a new 32-byte key: `openssl rand -base64 32`
+2. Update the key in Vercel dashboard (do not commit to source control)
+3. Existing encrypted leads from before the rotation cannot be decrypted with the new key. The admin panel will show `piiDecryptError: true` on those records — they can still be read from the email notification archive.
+4. After rotation, old leads expire within their original 90-day window.

--- a/docs/motors-credit-retention.md
+++ b/docs/motors-credit-retention.md
@@ -35,6 +35,14 @@ All lead data is also delivered to the dealer's notification email inbox (roadho
 
 ---
 
+## Transmission
+
+The full Social Insurance Number is **never transmitted in plaintext email**. When a SIN is provided, the admin notification email contains only a masked form (e.g. `•••-•••-789`, last 3 digits) with a note directing the recipient to retrieve the full SIN via the authenticated admin panel. The unmasked SIN exists only in the AES-256-GCM encrypted PII blob stored in KV, decrypted server-side exclusively through the authenticated `GET /api/motors/leads` endpoint. This ensures a compromised email account cannot expose a customer's full SIN.
+
+All other PII fields (DOB, address, income, bankruptcy/repo flags, employer) appear in full in the admin notification email. If email-at-rest encryption is required (e.g., under a lender data-handling agreement), enable Gmail or Workspace confidential mode for the receiving inbox.
+
+---
+
 ## Retention window
 
 **90 days** from the date of submission.

--- a/lib/motors/encrypt.ts
+++ b/lib/motors/encrypt.ts
@@ -1,0 +1,31 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+
+function getKey(): Buffer {
+  const raw = process.env.MOTORS_LEAD_ENCRYPTION_KEY
+  if (!raw) throw new Error('MOTORS_LEAD_ENCRYPTION_KEY not set')
+  const key = Buffer.from(raw, 'base64')
+  if (key.length !== 32) throw new Error('MOTORS_LEAD_ENCRYPTION_KEY must decode to exactly 32 bytes')
+  return key
+}
+
+// AES-256-GCM. Encoded as "iv:tag:ciphertext" (each segment base64-encoded).
+export function encryptPII(plaintext: string): string {
+  const key    = getKey()
+  const iv     = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const ct     = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const tag    = cipher.getAuthTag()
+  return `${iv.toString('base64')}:${tag.toString('base64')}:${ct.toString('base64')}`
+}
+
+export function decryptPII(token: string): string {
+  const key   = getKey()
+  const parts = token.split(':')
+  if (parts.length !== 3) throw new Error('Invalid PII token format')
+  const iv      = Buffer.from(parts[0], 'base64')
+  const tag     = Buffer.from(parts[1], 'base64')
+  const ct      = Buffer.from(parts[2], 'base64')
+  const decipher = createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(tag)
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8')
+}

--- a/lib/motors/encrypt.ts
+++ b/lib/motors/encrypt.ts
@@ -8,23 +8,32 @@ function getKey(): Buffer {
   return key
 }
 
-// AES-256-GCM. Encoded as "iv:tag:ciphertext" (each segment base64-encoded).
+// AES-256-GCM. Encoded as "v1:iv:tag:ciphertext" (each segment base64-encoded).
+// v1 prefix allows future key-rotation schemes without breaking existing blobs.
 export function encryptPII(plaintext: string): string {
   const key    = getKey()
   const iv     = randomBytes(12)
   const cipher = createCipheriv('aes-256-gcm', key, iv)
   const ct     = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
   const tag    = cipher.getAuthTag()
-  return `${iv.toString('base64')}:${tag.toString('base64')}:${ct.toString('base64')}`
+  return `v1:${iv.toString('base64')}:${tag.toString('base64')}:${ct.toString('base64')}`
 }
 
+// Accepts both v1 (4-part "v1:iv:tag:ct") and legacy 3-part ("iv:tag:ct") tokens.
 export function decryptPII(token: string): string {
   const key   = getKey()
   const parts = token.split(':')
-  if (parts.length !== 3) throw new Error('Invalid PII token format')
-  const iv      = Buffer.from(parts[0], 'base64')
-  const tag     = Buffer.from(parts[1], 'base64')
-  const ct      = Buffer.from(parts[2], 'base64')
+  let ivB64: string, tagB64: string, ctB64: string
+  if (parts.length === 4 && parts[0] === 'v1') {
+    [, ivB64, tagB64, ctB64] = parts as [string, string, string, string]
+  } else if (parts.length === 3) {
+    [ivB64, tagB64, ctB64] = parts as [string, string, string]
+  } else {
+    throw new Error('Invalid PII token format')
+  }
+  const iv       = Buffer.from(ivB64,  'base64')
+  const tag      = Buffer.from(tagB64, 'base64')
+  const ct       = Buffer.from(ctB64,  'base64')
   const decipher = createDecipheriv('aes-256-gcm', key, iv)
   decipher.setAuthTag(tag)
   return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8')

--- a/lib/motors/phone.ts
+++ b/lib/motors/phone.ts
@@ -1,0 +1,8 @@
+// Normalises a raw phone string to E.164 (+1XXXXXXXXXX) for North American numbers.
+// Returns null if the input cannot be resolved to a valid 10-digit NANP number.
+export function toE164(raw: string): string | null {
+  const digits = raw.replace(/\D/g, '')
+  if (digits.length === 10) return `+1${digits}`
+  if (digits.length === 11 && digits[0] === '1') return `+${digits}`
+  return null
+}

--- a/lib/motors/pixel.ts
+++ b/lib/motors/pixel.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fbq: (...args: any[]) => void
+  }
+}
+
+export function fbq(event: string, eventName: string, params?: Record<string, unknown>) {
+  if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
+  window.fbq(event, eventName, params)
+}

--- a/lib/motors/ratelimit.ts
+++ b/lib/motors/ratelimit.ts
@@ -10,7 +10,7 @@ function getRedis(): Redis {
 /**
  * Shared 60-second per-phone rate limit for all motors lead endpoints.
  * Returns true if the request may proceed; false if rate-limited.
- * Never throws — KV failure is non-blocking (allows the request through).
+ * Fails closed on KV error — a KV outage should not allow unbounded lead spam.
  */
 export async function checkPhoneRateLimit(cleanPhone: string): Promise<boolean> {
   try {
@@ -20,7 +20,8 @@ export async function checkPhoneRateLimit(cleanPhone: string): Promise<boolean> 
     if (hit) return false
     await redis.set(key, '1', { ex: 60 })
     return true
-  } catch {
-    return true
+  } catch (err) {
+    console.error('[motors/ratelimit] KV error — failing closed:', err)
+    return false
   }
 }

--- a/types/inventory.ts
+++ b/types/inventory.ts
@@ -51,11 +51,15 @@ export interface MotorsLead {
   creditRange?: string
   monthlyIncome?: string
   employmentStatus?: string
+  coSigner?: string
   message?: string
   status: 'new' | 'contacted' | 'approved' | 'closed' | 'dead'
   source: 'credit-form' | 'vehicle-form' | 'trade-in'
   deliveryStatus: 'sent' | 'failed'
   tradeIn?: MotorsLeadTradeIn
+  // AES-256-GCM encrypted JSON blob of sensitive PII fields (DOB, SIN, address,
+  // income, bankruptcy/repo flags, employer). Set only on credit-form leads.
+  pii?: string
 }
 
 export interface InventoryFilters {

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,10 @@
     {
       "path": "/api/motors/sync",
       "schedule": "0 15 * * *"
+    },
+    {
+      "path": "/api/motors/fb-token-check",
+      "schedule": "0 12 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

5-batch sprint from COUNSEL DIRECTIVE 001. All batches pass TypeScript strict check.

| Batch | Scope | Key files |
|---|---|---|
| 0 · PII Hardening | AES-256-GCM encryption of sensitive KV fields, 90-day TTL, SIN field, consent enforcement, customer receipt email | `lib/motors/encrypt.ts`, `leads/route.ts`, `CreditForm.tsx`, `docs/motors-credit-retention.md` |
| 1 · Meta Pixel | PageView, ViewContent (VDP), InitiateCheckout (credit app), Lead (both forms) | `lib/motors/pixel.ts`, `MetaPixel.tsx`, `PixelViewContent.tsx`, layout |
| 2 · Conversion | Price drop delta `-$X,XXX` on VDP gallery badge (matches card) | `VehicleGallery.tsx`, VDP page |
| 3 · Pipe Integrity | Rate limiter fails closed on KV error; E.164 phone validation on all 3 lead routes | `ratelimit.ts`, `lib/motors/phone.ts`, 3 API routes |
| 4 · FB Herald | Daily cron checks FB token validity + expiry; Resend alert at ≤14 days | `fb-token-check/route.ts`, `vercel.json` |

## Env vars to set in Vercel

```
MOTORS_LEAD_ENCRYPTION_KEY   openssl rand -base64 32    (base64 32-byte AES key)
NEXT_PUBLIC_META_PIXEL_ID    your Meta Pixel ID
MOTORS_FB_PAGE_ACCESS_TOKEN  copy of FB_PAGE_ACCESS_TOKEN GitHub Secret
MOTORS_FB_ALERT_EMAIL        email to receive token warnings
MOTORS_FB_APP_ID             Meta app ID (for expiry date check — optional but recommended)
MOTORS_FB_APP_SECRET         Meta app secret (pair with app ID above)
```

## TTL override note

Current TTL is 90 days. If a lender stip requires longer retention, change `LEAD_TTL_SECONDS` in `leads/route.ts` to `31536000` (1 year). See `docs/motors-credit-retention.md`.

## Manual verification checklist

- [ ] Set `MOTORS_LEAD_ENCRYPTION_KEY` in Vercel, submit a test credit app, confirm admin panel decrypts fields correctly
- [ ] Set `NEXT_PUBLIC_META_PIXEL_ID`, verify PageView fires in Meta Events Manager
- [ ] Trigger `GET /api/motors/fb-token-check` with CRON_SECRET — confirm `{status: "ok"}` response
- [ ] Submit lead with phone `invalid` → expect 400 "valid Canadian or US phone number"
- [ ] Submit credit form without checking consent → expect 400 "Consent is required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)