### PR TITLE
fix(motors): fb-token-check returns 200 unconfigured instead of 500 when FB vars unset

### DIFF
--- a/app/api/motors/fb-token-check/route.ts
+++ b/app/api/motors/fb-token-check/route.ts
@@ -43,7 +43,7 @@ export async function GET(req: NextRequest) {
   const appSecret = process.env.MOTORS_FB_APP_SECRET
 
   if (!token) {
-    return NextResponse.json({ error: 'MOTORS_FB_PAGE_ACCESS_TOKEN not set' }, { status: 500 })
+    return NextResponse.json({ status: 'unconfigured', note: 'MOTORS_FB_PAGE_ACCESS_TOKEN not set — skipping check' })
   }
 
   // Step 1: basic validity check via /me


### PR DESCRIPTION
## Summary
- `GET /api/motors/fb-token-check` was returning HTTP 500 with `{"error":"MOTORS_FB_PAGE_ACCESS_TOKEN not set"}` when the FB env vars are not yet configured
- Changed to HTTP 200 with `{"status":"unconfigured","note":"..."}` — missing config is a skip condition, not a server error
- Prevents daily cron from registering as a failed run before FB vars are provisioned

## Test plan
- [ ] `GET /api/motors/fb-token-check` (Bearer CRON_SECRET) with FB vars unset → 200 `{"status":"unconfigured"}`
- [ ] Once `MOTORS_FB_PAGE_ACCESS_TOKEN` is set, re-run → 200 `{"status":"ok",...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)